### PR TITLE
Fix newer GCC compile errors

### DIFF
--- a/cld2.gemspec
+++ b/cld2.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = CLD::VERSION
 
-  gem.add_dependency "ffi", "~> 1.9.3"
+  gem.add_dependency "ffi", ">= 1.9.3", "< 2"
 
   gem.add_development_dependency "rspec", "~> 2.14.1"
 end

--- a/ext/cld/extconf.rb
+++ b/ext/cld/extconf.rb
@@ -27,6 +27,9 @@ $objs = ["internal/cldutil.o",
   "internal/cld_generated_score_quad_octa_0122_2.o",
   "thunk.o"]
 
+# Prevents issues compiling with newer GCC versions
+$defs.push("-std=c++98")
+
 if have_library('stdc++')
   create_makefile('libcld2')
 end


### PR DESCRIPTION
In newer versions of GCC, compiling this gem fails with errors like;

```
Building native extensions. This could take a while...
ERROR:  Error installing cld2-1.0.3.gem:
  ERROR: Failed to build gem native extension.

    current directory: /var/lib/gems/2.5.0/gems/cld2-1.0.3/ext/cld
/usr/bin/ruby2.5 -r ./siteconf20180907-25240-hhk5um.rb extconf.rb
checking for -lstdc++... yes
creating Makefile

current directory: /var/lib/gems/2.5.0/gems/cld2-1.0.3/ext/cld
make "DESTDIR=" clean

current directory: /var/lib/gems/2.5.0/gems/cld2-1.0.3/ext/cld
make "DESTDIR="
compiling internal/cld2_generated_cjk_compatible.cc
compiling internal/cld2_generated_deltaoctachrome0122.cc
compiling internal/cld2_generated_distinctoctachrome0122.cc
compiling internal/cld2_generated_quadchrome0122_2.cc
compiling internal/cld_generated_cjk_delta_bi_4.cc
compiling internal/cld_generated_cjk_uni_prop_80.cc
internal/cld_generated_cjk_uni_prop_80.cc:7089:1: error: narrowing conversion of ‘-14’ from ‘int’ to ‘CLD2::uint8 {aka unsigned char}’ inside { } [-Wnarrowing]
 };
 ^
internal/cld_generated_cjk_uni_prop_80.cc:7089:1: error: narrowing conversion of ‘-14’ from ‘int’ to ‘CLD2::uint8 {aka unsigned char}’ inside { } [-Wnarrowing]
internal/cld_generated_cjk_uni_prop_80.cc:7089:1: error: narrowing conversion of ‘-14’ from ‘int’ to ‘CLD2::uint8 {aka unsigned char}’ inside { } [-Wnarrowing]
[omitted]
Makefile:210: recipe for target 'internal/cld_generated_cjk_uni_prop_80.o' failed
make: *** [internal/cld_generated_cjk_uni_prop_80.o] Error 1

make failed, exit code 2

Gem files will remain installed in /var/lib/gems/2.5.0/gems/cld2-1.0.3 for inspection.
Results logged to /var/lib/gems/2.5.0/extensions/x86_64-linux/2.5.0/cld2-1.0.3/gem_make.out
```

As per the recommendation in https://github.com/CLD2Owners/cld2/issues/47#issuecomment-227426420 I have added the necessary flag to prevent these errors. The gem now compiles for me on Ubuntu 18.04 with gcc 7.3.0.